### PR TITLE
add a seed file that does some async await explaining

### DIFF
--- a/seed.js
+++ b/seed.js
@@ -1,0 +1,45 @@
+/**
+ * Welcome to the seed file! This seed file uses a newer language feature called...
+ *
+ *                  -=-= ASYNC...AWAIT -=-=
+ *
+ * Async-await is a joy to use! Read more about it in the MDN docs:
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function
+ *
+ * Now that you've got the main idea, check it out in practice below!
+ */
+const db = require('./server/db')
+const {User} = require('./server/db/models')
+
+async function seed () {
+  await db.sync({force: true})
+  // Whoa! Because we `await` the promise that db.sync returns, the next line will not be
+  // executed until that promise resolves!
+
+  const users = await Promise.all([
+    User.create({email: 'cody@email.com', password: '123'}),
+    User.create({email: 'murphy@email.com', password: '123'})
+  ])
+  // Wowzers! We can even `await` on the right-hand side of the assignment operator
+  // and store the result that the promise resolves to in a variable! This is nice!
+  console.log(`Seeded ${users.length} users`)
+  console.log(`Seeded successfully`)
+  process.exit(0)
+}
+
+// Execute the `seed` function
+// `Async` functions always return a promise, so we can use `catch` to handle any errors
+// that might occur inside of `seed`
+seed().catch(err => {
+  console.error(err.message)
+  console.error(err.stack)
+  process.exit(1)
+})
+
+/*
+ * note: everything outside of the async function is totally synchronous
+ * The console.log below will occur before any of the logs that occur inside
+ * of the async function
+ */
+console.log('Seeding...')

--- a/seed.js
+++ b/seed.js
@@ -14,6 +14,7 @@ const {User} = require('./server/db/models')
 
 async function seed () {
   await db.sync({force: true})
+  console.log('db synced!')
   // Whoa! Because we `await` the promise that db.sync returns, the next line will not be
   // executed until that promise resolves!
 
@@ -23,23 +24,28 @@ async function seed () {
   ])
   // Wowzers! We can even `await` on the right-hand side of the assignment operator
   // and store the result that the promise resolves to in a variable! This is nice!
-  console.log(`Seeded ${users.length} users`)
-  console.log(`Seeded successfully`)
-  process.exit(0)
+  console.log(`seeded ${users.length} users`)
+  console.log(`seeded successfully`)
 }
 
 // Execute the `seed` function
 // `Async` functions always return a promise, so we can use `catch` to handle any errors
 // that might occur inside of `seed`
-seed().catch(err => {
-  console.error(err.message)
-  console.error(err.stack)
-  process.exit(1)
-})
+seed()
+  .catch(err => {
+    console.error(err.message)
+    console.error(err.stack)
+    process.exitCode = 1
+  })
+  .then(() => {
+    console.log('closing db connection')
+    db.close()
+    console.log('db connection closed')
+  })
 
 /*
  * note: everything outside of the async function is totally synchronous
  * The console.log below will occur before any of the logs that occur inside
  * of the async function
  */
-console.log('Seeding...')
+console.log('seeding...')


### PR DESCRIPTION
Per discussion yesterday.

I thought about the difference between using `try-catch` inside the `async` function vs. using a final `.catch` on the promise that `seed` returns, and erred on the latter because it feels slightly more important to demonstrate that async functions always return promises. But I could be convinced otherwise.