### PR TITLE
delete the deploy branch even when deploy fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build-client": "webpack",
     "build-client-watch": "webpack -w",
-    "deploy": "git checkout -b deploy && webpack -p && git add -f public/bundle.js public/bundle.js.map && git commit --allow-empty -m 'Deploying' && git push --force heroku deploy:master && git checkout master && git branch -D deploy",
+    "deploy": "script/deploy",
     "seed": "node seed.js",
     "start": "node server",
     "start-dev": "npm run build-client-watch & npm run start-server",

--- a/script/deploy
+++ b/script/deploy
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# set -e tells bash to terminate if any line terminates with an error
+set -e
+
+# trapping EXIT with this cleanup function protects us from errors where
+# we end up with the `deploy` branch checked out
+
+# cleanup_at_exit will always run at the end of this script
+
+function cleanup_at_exit {
+  git checkout master
+  git branch -D deploy
+}
+trap cleanup_at_exit EXIT
+
+git checkout -b deploy
+webpack -p
+git add -f public/bundle.js public/bundle.js.map
+git commit --allow-empty -m 'Deploying'
+git push --force heroku deploy:master

--- a/script/deploy
+++ b/script/deploy
@@ -1,21 +1,46 @@
 #!/usr/bin/env bash
 
-# set -e tells bash to terminate if any line terminates with an error
+# Hello, welcome to a bash script.
+
+# This bash script deploys your boilermaker application.
+
+# On the terminal you run individual
+# bash commands, and this file strings a bunch of commands together.
+
+# The first line of this file, or the `hashbang`, tells the system to
+# execute the text of this file as a bash program.
+
+# We want this entire script to exit if any single line fails.
+# So we set the `-e` flag.
 set -e
 
-# trapping EXIT with this cleanup function protects us from errors where
-# we end up with the `deploy` branch checked out
+# If our deploy fails partway through we want to clean up after ourselves.
+# This next block is like a try/catch for our entire script.
 
-# cleanup_at_exit will always run at the end of this script
+# We trap any program EXIT and run this function.
+# Whether the deploy succeeds or fails, we'll clean up the deploy branch.
 
 function cleanup_at_exit {
+  # return to your master branch
   git checkout master
+  
+  # remove the deploy branch
   git branch -D deploy
 }
 trap cleanup_at_exit EXIT
 
+# checks out a new branch called "deploy". Note that the name "deploy" here isn't magical,
+# but it needs to match the name of the branch we specify when we push to our heroku remote.
 git checkout -b deploy
+
+# webpack will run in "production mode"
 webpack -p
+
+# "force" add the otherwise gitignored build files
 git add -f public/bundle.js public/bundle.js.map
+
+# create a commit, even if nothing changed
 git commit --allow-empty -m 'Deploying'
+
+# push your local "deploy" branch to the "master" branch on heroku
 git push --force heroku deploy:master


### PR DESCRIPTION
I have observed students running into broken deploys and ending up in confusing interim states when they run `npm run deploy`. They are unexpectedly in a `deploy` branch.

Thoughts?