### PR TITLE
move axios mocking to its own file

### DIFF
--- a/client/mock-axios.js
+++ b/client/mock-axios.js
@@ -1,0 +1,4 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+const mockAxios = new MockAdapter(axios)
+export default mockAxios;

--- a/client/mock-axios.js
+++ b/client/mock-axios.js
@@ -1,4 +1,0 @@
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-const mockAxios = new MockAdapter(axios)
-export default mockAxios;

--- a/client/store/user.spec.js
+++ b/client/store/user.spec.js
@@ -2,13 +2,11 @@
 
 import {expect} from 'chai'
 import {me, logout} from './user'
-import axios from 'axios'
-import MockAdapter from 'axios-mock-adapter'
+import mockAxios from '../mock-axios';
 import configureMockStore from 'redux-mock-store'
 import thunkMiddleware from 'redux-thunk'
 import history from '../history'
 
-const mockAxios = new MockAdapter(axios)
 const middlewares = [thunkMiddleware]
 const mockStore = configureMockStore(middlewares)
 

--- a/client/store/user.spec.js
+++ b/client/store/user.spec.js
@@ -2,7 +2,8 @@
 
 import {expect} from 'chai'
 import {me, logout} from './user'
-import mockAxios from '../mock-axios';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
 import configureMockStore from 'redux-mock-store'
 import thunkMiddleware from 'redux-thunk'
 import history from '../history'
@@ -12,14 +13,17 @@ const mockStore = configureMockStore(middlewares)
 
 describe('thunk creators', () => {
   let store
+  let mockAxios
 
   const initialState = {user: {}}
 
   beforeEach(() => {
+    mockAxios = new MockAdapter(axios);
     store = mockStore(initialState)
   })
 
   afterEach(() => {
+    mockAxios.restore()
     store.clearActions()
   })
 

--- a/client/store/user.spec.js
+++ b/client/store/user.spec.js
@@ -2,8 +2,8 @@
 
 import {expect} from 'chai'
 import {me, logout} from './user'
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
 import configureMockStore from 'redux-mock-store'
 import thunkMiddleware from 'redux-thunk'
 import history from '../history'
@@ -18,7 +18,7 @@ describe('thunk creators', () => {
   const initialState = {user: {}}
 
   beforeEach(() => {
-    mockAxios = new MockAdapter(axios);
+    mockAxios = new MockAdapter(axios)
     store = mockStore(initialState)
   })
 


### PR DESCRIPTION
I've had a couple students run into an issue when they attempt to create more tests around their store.

The `axios-mock-adapter` library is very confusing if you create two `MockAdapter`s wrapping the same axios adapter.

```js
import axios from 'axios'
import MockAdapter from 'axios-mock-adapter'

const mock1 = new MockAdapter(axios)
const mock2 = new MockAdapter(axios)

mock1.onGet('/path').reply(200, { some: 'data' })
axios.get('/path') // This will NOT match the `onGet('path')` specified above.
```

In practice `mock1` and `mock2` would be created in separate test files.


This happens because `axios-mock-adapter` overwrites a property on the `axios` instance passed into it: https://github.com/ctimmerm/axios-mock-adapter/blob/master/src/index.js#L39