### PR TITLE
fix(server): 404 for missing files

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -58,6 +58,17 @@ const createApp = () => {
   // static file-serving middleware
   app.use(express.static(path.join(__dirname, '..', 'public')))
 
+  // any remaining requests with an extension (.js, .css, etc.) send 404
+  .use((req, res, next) => {
+    if (path.extname(req.path).length) {
+      const err = new Error('Not found')
+      err.status = 404
+      next(err)
+    } else {
+      next()
+    }
+  })
+
   // sends index.html
   app.use('*', (req, res) => {
     res.sendFile(path.join(__dirname, '..', 'public/index.html'))


### PR DESCRIPTION
Students get horribly confused by this all the time. They aren't building a bundle, but instead of a 404, the server sends the index.html page. The browser tries to parse it as a script and logs "unexpected token <".

This PR adds a handler which sends 404s for any paths ending in a file extension. So if they request bundle.js and there is no bundle… 404. It still allows for the home page to be sent for any other path, e.g. `/about`.