### PR TITLE
fix(linter): restore missing expression parens

### DIFF
--- a/server/auth/google.js
+++ b/server/auth/google.js
@@ -36,11 +36,11 @@ if (!process.env.GOOGLE_CLIENT_ID || !process.env.GOOGLE_CLIENT_SECRET) {
     const email = profile.emails[0].value
 
     User.find({where: {googleId}})
-      .then(foundUser => foundUser
+      .then(foundUser => (foundUser
         ? done(null, foundUser)
         : User.create({name, email, googleId})
           .then(createdUser => done(null, createdUser))
-      )
+      ))
       .catch(done)
   })
 


### PR DESCRIPTION
In fixing conflicts to merge in the linter PR, one pair of parens was lost, resulting in an arrow-with-ambiguous-condition warning. This fixes that.