### PR TITLE
eliminates the need to update the db name

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Now that you've got the code, follow these steps to get acclimated:
 
 * Update project name and description in `package.json` file
 * `npm install`, or `yarn install` - whatever you're into
-* Create two postgres databases: `boilermaker` and `boilermaker-test` (you can substitute these with the name of your own application - just be sure to go through and change the `package.json` and `server/db/db.js` to refer to the new names)
+* Create two postgres databases: `boilermaker` and `boilermaker-test` (you can substitute these with the name of your own application - just be sure to go through and change the `package.json` to refer to the new name)
   * By default, running `npm test` will use `boilermaker-test`, while regular development uses `boilermaker`
 * Create a file called `secrets.js` in the project root
   * This file is `.gitignore`'d, and will *only* be required in your *development* environment

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -1,6 +1,7 @@
+const dbName = require('../../package.json').name
 const Sequelize = require('sequelize')
 const db = new Sequelize(
-  process.env.DATABASE_URL || 'postgres://localhost:5432/boilermaker', {
+  process.env.DATABASE_URL || `postgres://localhost:5432/${dbName}`, {
     logging: false
   }
 )


### PR DESCRIPTION
### Assignee Tasks

- [x] added unit tests (or none needed)
- [x] written relevant docs (or none needed)
- [x] referenced any relevant issues (or none exist)

### Guidelines

Please add a description of this Pull Request's motivation, scope, outstanding issues or potential alternatives, reasoning behind the current solution, and any other relevant information for posterity.

---

*PR Notes Here*
Allows users to update the name of the project in the package.json and have the dbname be generated based on the name of the project.  This saves users a step in customizing the initial codebase.

Also, an alternative to _dbName_ could be _pkgName_ or _projectName_.
