### PR TITLE
fix(redux/user): stop unrelated errors from logging out user during auth

### DIFF
--- a/client/store/user.js
+++ b/client/store/user.js
@@ -34,9 +34,10 @@ export const auth = (email, password, method) =>
       .then(res => {
         dispatch(getUser(res.data))
         history.push('/home')
+      }, authError => { // rare example: a good use case for parallel (non-catch) error handler
+        dispatch(getUser({error: authError}))
       })
-      .catch(error =>
-        dispatch(getUser({error})))
+      .catch(dispatchOrHistoryErr => console.error(dispatchOrHistoryErr))
 
 export const logout = () =>
   dispatch =>


### PR DESCRIPTION
### Assignee Tasks

- [ ] added unit tests (or none needed) – *skipped (shame on me / an exercise for students?)*
- [x] written relevant docs (or none needed) — *none needed*
- [x] referenced any relevant issues (or none exist) — closes #42

---

If an auth error occurs, the user is signed out. If an error occurs *after* auth, it is caught and logged.