### PR TITLE
fix(db): set database name to package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
     "postinstall": "touch secrets.js",
     "seed": "node script/seed.js",
     "start": "node server",
-    "start-dev": "NODE_ENV='development' npm run build-client-watch & npm run start-server",
+    "start-dev":
+      "NODE_ENV='development' npm run build-client-watch & npm run start-server",
     "start-server": "nodemon server -e html,js,scss --ignore public",
-    "test": "NODE_ENV='test' DATABASE_URL='postgres://localhost:5432/boilermaker-test' mocha ./server/**/*.spec.js ./server/**/**/*.spec.js ./client/**/*.spec.js --compilers js:babel-register"
+    "test":
+      "NODE_ENV='test' mocha ./server/**/*.spec.js ./server/**/**/*.spec.js ./client/**/*.spec.js --compilers js:babel-register"
   },
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -14,11 +14,9 @@
     "postinstall": "touch secrets.js",
     "seed": "node script/seed.js",
     "start": "node server",
-    "start-dev":
-      "NODE_ENV='development' npm run build-client-watch & npm run start-server",
+    "start-dev": "NODE_ENV='development' npm run build-client-watch & npm run start-server",
     "start-server": "nodemon server -e html,js,scss --ignore public",
-    "test":
-      "NODE_ENV='test' mocha ./server/**/*.spec.js ./server/**/**/*.spec.js ./client/**/*.spec.js --compilers js:babel-register"
+    "test": "NODE_ENV='test' mocha ./server/**/*.spec.js ./server/**/**/*.spec.js ./client/**/*.spec.js --compilers js:babel-register"
   },
   "author": "",
   "license": "ISC",

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -1,6 +1,11 @@
 const Sequelize = require('sequelize')
+const pkg = require('../../package.json')
+
+const databaseName = pkg.name + (process.env.NODE_ENV === 'test' ? '-test' : '')
+
 const db = new Sequelize(
-  process.env.DATABASE_URL || 'postgres://localhost:5432/boilermaker', {
+  process.env.DATABASE_URL || `postgres://localhost:5432/${databaseName}`,
+  {
     logging: false
   }
 )


### PR DESCRIPTION
This removes the hardcoded database url for testing and sets the default database name to be the package name (with '-test' at the end if the node env is testing).

Closes #34  