### PR TITLE
fix(nodemon): ignore client folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "seed": "node script/seed.js",
     "start": "node server",
     "start-dev": "NODE_ENV='development' npm run build-client-watch & npm run start-server",
-    "start-server": "nodemon server -e html,js,scss --ignore public",
+    "start-server": "nodemon server -e html,js,scss --ignore public --ignore client",
     "test": "NODE_ENV='test' mocha ./server/**/*.spec.js ./server/**/**/*.spec.js ./client/**/*.spec.js --compilers js:babel-register"
   },
   "author": "",


### PR DESCRIPTION
### Assignee Tasks

- [x] added unit tests (or none needed)
- [x] written relevant docs (or none needed)
- [x] referenced any relevant issues (or none exist)

---

Closes #69.

There were two options: whitelist (only watch `server`) or blacklist (ignore `public`, ignore `client`). The former would make more sense but if in the future we move the `db` out of `server` then I can foresee a nasty bug where people fail to realize that the Sequelize models changing doesn't cause a restart. The blacklist style is a little leaky, e.g. there could be false positives (editing the deploy script?), but that's better than failing to restart when necessary IMHO.