### PR TITLE
feat(user): hide password and salt from client

### DIFF
--- a/server/db/models/user.js
+++ b/server/db/models/user.js
@@ -14,7 +14,6 @@ const User = db.define('user', {
     // This is a hack to get around Sequelize's lack of a "private" option.
     get() {
       return () => this.getDataValue('password')
-      // return function () { return this.getDataValue('password') }
     }
   },
   salt: {

--- a/server/db/models/user.js
+++ b/server/db/models/user.js
@@ -9,10 +9,21 @@ const User = db.define('user', {
     allowNull: false
   },
   password: {
-    type: Sequelize.STRING
+    type: Sequelize.STRING,
+    // Making `.password` act like a func hides it when serializing to JSON.
+    // This is a hack to get around Sequelize's lack of a "private" option.
+    get() {
+      return () => this.getDataValue('password')
+      // return function () { return this.getDataValue('password') }
+    }
   },
   salt: {
-    type: Sequelize.STRING
+    type: Sequelize.STRING,
+    // Making `.salt` act like a function hides it when serializing to JSON.
+    // This is a hack to get around Sequelize's lack of a "private" option.
+    get () {
+      return () => this.getDataValue('salt')
+    }
   },
   googleId: {
     type: Sequelize.STRING
@@ -25,7 +36,7 @@ module.exports = User
  * instanceMethods
  */
 User.prototype.correctPassword = function (candidatePwd) {
-  return User.encryptPassword(candidatePwd, this.salt) === this.password
+  return User.encryptPassword(candidatePwd, this.salt()) === this.password()
 }
 
 /**
@@ -49,7 +60,7 @@ User.encryptPassword = function (plainText, salt) {
 const setSaltAndPassword = user => {
   if (user.changed('password')) {
     user.salt = User.generateSalt()
-    user.password = User.encryptPassword(user.password, user.salt)
+    user.password = User.encryptPassword(user.password(), user.salt())
   }
 }
 


### PR DESCRIPTION
### Assignee Tasks

- [ ] added unit tests (or none needed)
- [x] written relevant docs (or none needed)
- [x] referenced any relevant issues (or none exist)

---

Based on [this technique](https://github.com/sequelize/sequelize/issues/2132#issuecomment-341292873), hides the password and salt when serializing to JSON. Less brutal and bug-prone than overriding `toJSON`, too.

Closes #36.