### PR TITLE
babel-preset-stage-2 fix

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  presets: ['@babel/react', '@babel/env', '@babel/stage-2']
+  presets: ['@babel/react', '@babel/env', ["@babel/preset-stage-2", { "decoratorsLegacy": true }]]
   /*
     Babel uses these "presets" to know how to transpile your Javascript code. Here's what we're saying with these:
 


### PR DESCRIPTION
### Assignee Tasks

- [ ] added unit tests (or none needed)
- [ ] referenced any relevant issues (or none exist)
- [ ] written relevant docs (or none needed)

### Guidelines

Please add a description of this Pull Request's motivation, scope, outstanding issues or potential alternatives, reasoning behind the current solution, and any other relevant information for posterity.

---

*Your PR Notes Here*

Since the past few days, I have been getting this error message 
```The new decorators proposal is not supported yet. You must pass the `"decoratorsLegacy": true` option to @babel/preset-stage-2```


After more research, it was determined that we have to add `"decoratorsLegacy": true` to `preset-stage-2` in the `.babelrc` file. 

You can find more info here: https://github.com/babel/babel/issues/7786