### PR TITLE
added support for importing jsx files without specifying a file type

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,9 @@ module.exports = {
     path: __dirname,
     filename: './public/bundle.js'
   },
+  resolve: {
+    extensions: ['.js', '.jsx']
+  },
   devtool: 'source-map',
   module: {
     rules: [


### PR DESCRIPTION
### Assignee Tasks

- [x] added unit tests (or none needed)
- [x] written relevant docs (or none needed)
- [x] referenced any relevant issues (or none exist)

### Guidelines

Please add a description of this Pull Request's motivation, scope, outstanding issues or potential alternatives, reasoning behind the current solution, and any other relevant information for posterity.

---

*Your PR Notes Here*

added `resolve` configuration in `webpack.config.js` to allow the importing of jsx files without putting .jsx at the end of the file name.