### PR TITLE
docs(readme): restore missing flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ CI is not about testing per se – it's about _continuously integrating_ your ch
 2.  Un-comment the bottom part of `.travis.yml` (the `before_deploy` and `deploy` sections)
 3.  Add your Heroku app name to `deploy.app`, where it says "YOUR HEROKU APP NAME HERE". For example, if your domain is `cool-salty-conifer.herokuapp.com`, your app name is `cool-salty-conifer`.
 4.  Install the Travis CLI tools by following [the instructions here](https://github.com/travis-ci/travis.rb#installation).
-5.  Run `travis encrypt $(heroku auth:token)` to encrypt your Heroku API key. _**Warning:** do not run the `--add` command suggested by Travis, that will rewrite part of our existing config!_
+5.  Run `travis encrypt $(heroku auth:token) --org` to encrypt your Heroku API key. _**Warning:** do not run the `--add` command suggested by Travis, that will rewrite part of our existing config!_
 6.  Copy-paste your encrypted API key into the `.travis.yml` file under `deploy.api_key.secure`, where it says "YOUR ENCRYPTED API KEY HERE".
 7.  `git add -A && git commit -m 'travis: activate deployment' && git push -u origin f/travis-deploy`
 8.  Make a PR for the new branch, get it approved, and merge it into master.


### PR DESCRIPTION
Brings back the `--org` flag in the deployment instructions (accidentally steamrolled in a previous PR).

I went over the other changes with a fine-toothed comb and saw no other accidental deletions.