### PR TITLE
fix(npm-merge-driver): only run if a `.git` folder is present

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint ./ --ignore-path .gitignore",
     "lint-fix": "npm run lint -- --fix",
     "precommit": "# lint-staged # un-comment to enable",
-    "prepare": "npm-merge-driver install",
+    "prepare": "if [ -d .git ]; then npm-merge-driver install; fi",
     "prettify": "prettier --write \"**/*.{js,jsx,json,css,scss,md}\"",
     "postinstall": "touch secrets.js",
     "seed": "node script/seed.js",


### PR DESCRIPTION
### Assignee Tasks

* [ ] added unit tests (or none needed)
* [ ] written relevant docs (or none needed)
* [x] referenced any relevant issues (or none exist)

Closes #121 — maybe?

This needs actual testing with Heroku deployment. *DO NOT MERGE* until properly tested.