### PR TITLE
feat(deployment): encrypt heroku auth token in bash

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build-client": "webpack",
     "build-client-watch": "webpack -w",
     "deploy": "script/deploy",
+    "heroku-token": "script/encrypt-heroku-auth-token",
     "lint": "eslint ./ --ignore-path .gitignore",
     "lint-fix": "npm run lint -- --fix",
     "precommit": "# lint-staged # un-comment to enable",

--- a/script/encrypt-heroku-auth-token
+++ b/script/encrypt-heroku-auth-token
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -e
+
+function cleanup_at_exit {
+  # remove temporary key file
+  rm tmp.pem
+}
+
+trap cleanup_at_exit EXIT
+
+# Get the repo name from the `origin` git remote.
+export REPO=$(git remote get-url origin | \
+    sed 's/^.*[\/:]\([^\/:]*\)\/\([^\/]*\)$/\1\/\2/' | \
+    sed 's/^\(.*\)\.git$/\1/'
+)
+
+# Get the Travis public key for this repo.
+export TRAVIS_KEY=$(curl --silent https://api.travis-ci.org/repos/$REPO/key)
+
+# Save the key to a file.
+node -e "console.log($TRAVIS_KEY['key'])" > tmp.pem
+
+# Generate a Heroku token, encrypt and encode it and print it in YAML.
+echo -n $(heroku auth:token) | \
+    openssl rsautl -encrypt -pubin -inkey tmp.pem | \
+    base64 | awk '{print "    secure: "$1}'


### PR DESCRIPTION
Added a script to encrypt the Heroku auth token with bash tools, avoiding the need to install the Travis CLI tools. This script requires:
* `awk`
* `base64`
* `curl`
* `git`
* The Heroku CLI tools
* `node`
* `openssl`
* `sed`
