### PR TITLE
set ENV vars on server process when running npm run start-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "postinstall": "touch secrets.js",
     "seed": "node script/seed.js",
     "start": "node server",
-    "start-dev": "NODE_ENV='development' npm run build-client-watch & npm run start-server",
+    "start-dev": "NODE_ENV='development' npm run build-client-watch & NODE_ENV='development' npm run start-server",
     "start-server": "nodemon server -e html,js,scss --ignore public --ignore client",
     "test": "NODE_ENV='test' mocha \"./server/**/*.spec.js\" \"./client/**/*.spec.js\" \"./script/**/*.spec.js\" --require @babel/polyfill --require @babel/register"
   },


### PR DESCRIPTION
It appears that you need to specify the environment variable for the `&`ed child process as well.

Students were getting `pocess.env.NODE_ENV === undefined`.