### PR TITLE
fix(models): salt and hash passwords for bulk-created users

### DIFF
--- a/server/db/models/user.js
+++ b/server/db/models/user.js
@@ -65,3 +65,6 @@ const setSaltAndPassword = user => {
 
 User.beforeCreate(setSaltAndPassword)
 User.beforeUpdate(setSaltAndPassword)
+User.beforeBulkCreate(users => {
+  users.forEach(setSaltAndPassword)
+})


### PR DESCRIPTION
This ensures that any users created in bulk have their passwords automatically salted and hashed before they're saved to the database. It might not ever be necessary in a production environment, but can make seeding users easier.