### PR TITLE
feat(travis): run build as part of testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,11 @@ install:
   - npm ci # faster, goes only from package-lock
 before_script:
   - psql -c 'create database "boilermaker-test";' -U postgres # remember to change this name if you change it elsewhere (e.g. package.json)
+script:
+  - npm test             # test the code
+  - npm run build-client # make the bundle
 
 # before_deploy:
-#   - npm run build-client # make the bundle
 #   - rm -rf node_modules # omit from the tarball, since we skip cleanup
 # deploy:
 #   skip_cleanup: true # prevents travis from deleting the build


### PR DESCRIPTION
### Assignee Tasks

* [x] added unit tests (or none needed)
* [x] written relevant docs (or none needed)
* [x] referenced any relevant issues (or none exist)

### Guidelines

Closes #162

The [default Node build script on Travis](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#default-build-script) is to just run `npm test`. This PR augments the script to also build the bundle. A failing build (e.g. due to syntax errors or broken module paths) will thus fail Travis, making it harder for people to merge broken bundles (assuming their master branch is protected).