### PR TITLE
Updated sequelize to 5.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,3 +55,7 @@
     - Found out that as long as react- is 16.4+, the updates should be fine
 - react update to 16.8.6 from 16.4.2
 - react-dom update to 16.8.6 from 16.4.2
+
+## Thursday, April 11th, 2019
+### Dependencies 
+- sequelize update to 5.3.1 from 5.2.15

--- a/package-lock.json
+++ b/package-lock.json
@@ -8721,9 +8721,9 @@
       }
     },
     "sequelize": {
-      "version": "5.2.15",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.2.15.tgz",
-      "integrity": "sha512-xXTgV+FVqVCpBuC/6kQV2f9aSs5NSSKESx6TsuLHc4TzQy1Q7lWQHwXskBt6cBfQCY899z4iHYpAskEecVUO7w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.3.1.tgz",
+      "integrity": "sha512-h79d4ZvXee/pgwuPhqxHZ8Llz/v4vufspn0tfBR2ggYJBL9K1GTuYg5Bp848Y642scanJKwz3LfiyT/ZPfBcxQ==",
       "requires": {
         "bluebird": "^3.5.0",
         "cls-bluebird": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "redux": "^4.0.1",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",
-    "sequelize": "^5.2.15",
+    "sequelize": "^5.3.1",
     "socket.io": "^2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Assignee Tasks

* Updated Sequelize to its latest version which was released about 15 hours ago to fix a security vulnerability

### Guidelines

Keeping the packages updated 

---
