### PR TITLE
replaces deprecated findById with findByPk

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -33,7 +33,7 @@ passport.serializeUser((user, done) => done(null, user.id))
 
 passport.deserializeUser(async (id, done) => {
   try {
-    const user = await db.models.user.findById(id)
+    const user = await db.models.user.findByPk(id)
     done(null, user)
   } catch (err) {
     done(err)


### PR DESCRIPTION
### Assignee Tasks

* [x] added unit tests (or none needed)
* [x] written relevant docs (or none needed)
* [x] referenced any relevant issues (or none exist)

Sequelize v5 no longer supports the `Model.findById` method: it's been replaced by `findByPk`. We were still using `findById` in the `deserializeUser` function, which threw an error when a user signed in.
