### PR TITLE
[WIP] support async imports in npm modules

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+const pathLib = require('path')
 const isDev = process.env.NODE_ENV === 'development'
 
 module.exports = {
@@ -7,8 +8,10 @@ module.exports = {
     './client/index.js'
   ],
   output: {
-    path: __dirname,
-    filename: './public/bundle.js'
+    chunkFilename: '[name].bundle.js',
+    filename: 'bundle.js',
+    path: pathLib.join(__dirname, 'public'),
+    publicPath: '/'
   },
   resolve: {
     extensions: ['.js', '.jsx']


### PR DESCRIPTION
Some dependencies make use of async imports: `import('module-name').then((defaultExport) => {})`

This results in chunked bundles `0.bundle.js`.

As configured, webpack will assume these should be fetched as `GET /public/0.bundle.js`

But the URL should be `GET /0.bundle.js`.

- [x] support serving split bundles in development mode
- [ ] support deploying split bundles in production mode (will require update to deploy script to find these file)
