### PR TITLE
use webpack middleware to avoid stale bundles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1358,8 +1358,7 @@
     "ansi-colors": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
-      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
-      "dev": true
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw=="
     },
     "ansi-escapes": {
       "version": "3.2.0",
@@ -2700,8 +2699,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
       "version": "5.2.1",
@@ -3363,7 +3361,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-      "dev": true,
       "requires": {
         "prr": "~1.0.1"
       }
@@ -6202,7 +6199,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-      "dev": true,
       "requires": {
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
@@ -6211,14 +6207,12 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -6233,7 +6227,6 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -6385,7 +6378,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -6393,8 +6385,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -7933,8 +7924,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -7993,8 +7983,7 @@
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-      "dev": true
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -10150,8 +10139,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -10379,6 +10367,34 @@
             "decamelize": "^1.2.0"
           }
         }
+      }
+    },
+    "webpack-dev-middleware": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
+      "integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
+      "requires": {
+        "memory-fs": "^0.4.1",
+        "mime": "^2.4.4",
+        "mkdirp": "^0.5.1",
+        "range-parser": "^1.2.1",
+        "webpack-log": "^2.0.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+        }
+      }
+    },
+    "webpack-log": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
+      "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
+      "requires": {
+        "ansi-colors": "^3.0.0",
+        "uuid": "^3.3.2"
       }
     },
     "webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "postinstall": "touch secrets.js",
     "seed": "node script/seed.js",
     "start": "node server",
-    "start-dev": "NODE_ENV='development' npm run build-client-watch & NODE_ENV='development' npm run start-server",
+    "start-dev": "NODE_ENV='development' npm run start-server",
     "start-server": "nodemon server -e html,js,scss --ignore public --ignore client",
     "test": "NODE_ENV='test' mocha \"./server/**/*.spec.js\" \"./client/**/*.spec.js\" \"./script/**/*.spec.js\" --require @babel/polyfill --require @babel/register"
   },
@@ -61,7 +61,8 @@
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",
     "sequelize": "^5.3.1",
-    "socket.io": "^2.2.0"
+    "socket.io": "^2.2.0",
+    "webpack-dev-middleware": "^3.7.2"
   },
   "devDependencies": {
     "@babel/core": "^7.4.3",

--- a/server/index.js
+++ b/server/index.js
@@ -71,7 +71,10 @@ const createApp = () => {
   app.use('/api', require('./api'))
 
   // webpack dev middleware
-  const outputPath = path.resolve(__dirname, './public')
+  //   This middleware will match requests to GET /bundle.js
+  //   An advantage to using this middleware is if webpack is
+  //   in the middle of a compilation the request will not
+  //   return content until the fresh bundle is availble.
   app.use(
     webpackMiddleware(
       webpack({

--- a/server/index.js
+++ b/server/index.js
@@ -75,20 +75,25 @@ const createApp = () => {
   //   An advantage to using this middleware is if webpack is
   //   in the middle of a compilation the request will not
   //   return content until the fresh bundle is availble.
-  app.use(
-    webpackMiddleware(
-      webpack({
-        ...webpackConfig,
-        output: {
-          filename: 'bundle.js',
-          pathinfo: false
+  //
+  //   In production, the bundle will be generated and stored in the
+  //   public/ directory.
+  if (process.env.NODE_ENV === 'development') {
+    app.use(
+      webpackMiddleware(
+        webpack({
+          ...webpackConfig,
+          output: {
+            filename: 'bundle.js',
+            pathinfo: false
+          }
+        }),
+        {
+          publicPath: '/'
         }
-      }),
-      {
-        publicPath: '/'
-      }
+      )
     )
-  )
+  }
 
   // static file-serving middleware
   app.use(express.static(path.join(__dirname, '..', 'public')))

--- a/server/index.js
+++ b/server/index.js
@@ -9,6 +9,9 @@ const db = require('./db')
 const sessionStore = new SequelizeStore({db})
 const PORT = process.env.PORT || 8080
 const app = express()
+const webpack = require('webpack')
+const webpackMiddleware = require('webpack-dev-middleware')
+const webpackConfig = require('../webpack.config.js')
 const socketio = require('socket.io')
 module.exports = app
 
@@ -66,6 +69,23 @@ const createApp = () => {
   // auth and api routes
   app.use('/auth', require('./auth'))
   app.use('/api', require('./api'))
+
+  // webpack dev middleware
+  const outputPath = path.resolve(__dirname, './public')
+  app.use(
+    webpackMiddleware(
+      webpack({
+        ...webpackConfig,
+        output: {
+          filename: 'bundle.js',
+          pathinfo: false
+        }
+      }),
+      {
+        publicPath: '/'
+      }
+    )
+  )
 
   // static file-serving middleware
   app.use(express.static(path.join(__dirname, '..', 'public')))

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const isDev = process.env.NODE_ENV === 'development'
 
 module.exports = {
@@ -13,7 +14,7 @@ module.exports = {
   resolve: {
     extensions: ['.js', '.jsx']
   },
-  devtool: 'source-map',
+  devtool: 'cheap-module-eval-source-map',
   watchOptions: {
     ignored: /node_modules/
   },
@@ -21,6 +22,7 @@ module.exports = {
     rules: [
       {
         test: /\.jsx?$/,
+        include: path.resolve(__dirname, 'client'),
         exclude: /node_modules/,
         loader: 'babel-loader'
       }


### PR DESCRIPTION
Replaces the multi-process bundle approach with `webpack-dev-middleware`

This is a common annoyance for students and shows up as this sequence while debugging:

1: Student makes change to front-end code and save file.
2: `webpack` **starts** bundling
3: Student reloads web browser, loading stale `bundle.js`. Student debugs against old code, possibly drawing incorrect conclusions about whether their changes were correct.
4: `webpack` **finishes** bundling
5: Student goes back to editor and makes more changes.
6: Cycle repeats.

I've regularly stepped into Sr Phase help tickets where students were in this cycle and did not realize it, having wasted quite a bit of time and having lost a lot of confidence in their sanity.

Using `webpack-dev-middleware` would increase a delay and the cycle would go like this:

1: Student makes change to front-end code and save file.
2: `webpack` **starts** bundling
3: Student reloads web browser, **server blocks until bundle is complete**, fresh bundle is served.

This PR includes an explanatory comment for students.
```js
  //   This middleware will match requests to GET /bundle.js
  //   An advantage to using this middleware is if webpack is
  //   in the middle of a compilation the request will not
  //   return content until the fresh bundle is availble.
  //
  //   In production, the bundle will be generated and stored in the
  //   public/ directory.
```