### PR TITLE
adds ssl config

### DIFF
--- a/server/db/db.js
+++ b/server/db/db.js
@@ -3,12 +3,33 @@ const pkg = require('../../package.json')
 
 const databaseName = pkg.name + (process.env.NODE_ENV === 'test' ? '-test' : '')
 
-const db = new Sequelize(
-  process.env.DATABASE_URL || `postgres://localhost:5432/${databaseName}`,
-  {
+let config
+
+if (process.env.DATABASE_URL) {
+  config = {
+    logging: false,
+    operatorsAliases: false,
+    dialect: 'postgres',
+    protocol: 'postgres',
+    ssl: true,
+    dialectOptions: {
+      ssl: {
+        require: true,
+        rejectUnauthorized: false
+      }
+    }
+  }
+} else {
+  config = {
     logging: false
   }
+}
+
+const db = new Sequelize(
+  process.env.DATABASE_URL || `postgres://localhost:5432/${databaseName}`,
+  config
 )
+
 module.exports = db
 
 // This is a global Mocha hook used for resource cleanup.

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -8,9 +8,6 @@ let config
 if (process.env.DATABASE_URL) {
   config = {
     logging: false,
-    operatorsAliases: false,
-    dialect: 'postgres',
-    protocol: 'postgres',
     ssl: true,
     dialectOptions: {
       ssl: {


### PR DESCRIPTION
Due to a recent update on Heroku SSL is needed for postgres connections. This PR adds the necessary options in our Sequelize connection instance so that deployment works. 